### PR TITLE
Changing setup.py to point to requirements_2018.txt seems to make som…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-emodpy~=1.16
-emod-typhoid
+emodpy==1.22.0.dev3
+emod-api==1.31.0.dev1
+emod-typhoid==0.0.5

--- a/requirements_2018.txt
+++ b/requirements_2018.txt
@@ -1,3 +1,0 @@
-emodpy==1.22.0.dev3
-emod-api==1.31.0.dev1
-emod-typhoid==0.0.5

--- a/requirements_future.txt
+++ b/requirements_future.txt
@@ -1,0 +1,2 @@
+emodpy~=1.16
+emod-typhoid

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
     ext_name = "emodpy_typhoid"
 
-with open('requirements_2018.txt') as requirements_file:
+with open('requirements.txt') as requirements_file:
     requirements = requirements_file.read().split("\n")
 
 setuptools.setup(


### PR DESCRIPTION
…ething in RTD land unhappy. Since we're using the 2018 model for the meantime, let's just make the 'ideal' requirements.txt the one with the funny name and make what was _2018 the one with the standard name, and see what happens.