### PR TITLE
https://github.com/InstituteforDiseaseModeling/jupyter-notebooks-emod…

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,6 @@ disease transmission model.
    :titlesonly:
    :caption: Related documentation
 
-   emodpy Jupyter notebooks <https://docs.idmod.org/projects/jupyter-notebooks-emodpy/en/latest/>
    EMOD typhoid <https://docs.idmod.org/projects/emod-typhoid/en/latest/>
    emod-api <https://docs.idmod.org/projects/emod-api/en/latest/>
    emodpy <https://docs.idmod.org/projects/emodpy/en/latest/>


### PR DESCRIPTION
…py/issues/34, removing Juypter notebooks project from EMOD docs

Remove jupyter-notebooks-emodpy project from main TOC. Notebooks are broken, cannot
be run interactively off COMPS, and we don't have resources to maintain them.